### PR TITLE
feat: sendScreenEvent com propriedades opcionais (MR-495)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useblu/blu-lytics",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": false,
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/dispatchers/dispatchers.spec.ts
+++ b/src/dispatchers/dispatchers.spec.ts
@@ -3,6 +3,7 @@ import {
   sendScreenEvent,
   sendUserIdentification,
 } from './index';
+import { providersList } from '../providers';
 
 jest.mock('../initializers', () => ({
   userSelectedEnvironment: 'development',
@@ -11,6 +12,7 @@ jest.mock('../initializers', () => ({
 jest.mock('../providers', () => ({
   providersList: [
     {
+      name: 'FakeProvider',
       screenEvent: jest.fn(),
       customEvent: jest.fn(),
       userIdentification: jest.fn(),
@@ -20,6 +22,7 @@ jest.mock('../providers', () => ({
 
 jest.mock('../utils', () => ({
   isValidProvidersList: jest.fn(() => true),
+  checkIfMixPanelIsInitialized: jest.fn(),
 }));
 
 describe('Event dispatching functions', () => {
@@ -32,6 +35,7 @@ describe('Event dispatching functions', () => {
 
   beforeEach(() => {
     localStorage.setItem(localStorageKey, JSON.stringify([providers]));
+    localStorage.setItem('_bl_props', JSON.stringify({}));
   });
 
   it('should be dispatch sendScreenEvent', () => {
@@ -40,6 +44,68 @@ describe('Event dispatching functions', () => {
     sendScreenEvent('TestScreen');
 
     expect(consoleLogSpy).toHaveBeenCalledWith('[blu-lytics]: Screen event: TestScreen');
+  });
+
+  it('should dispatch sendScreenEvent without properties keeping the legacy log format', () => {
+    const consoleLogSpy = jest.spyOn(console, 'log');
+
+    sendScreenEvent('TestScreen');
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('[blu-lytics]: Screen event: TestScreen');
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('TestScreen - '),
+    );
+  });
+
+  it('should dispatch sendScreenEvent merging defaultProperties with the provided properties', () => {
+    localStorage.setItem('_bl_props', JSON.stringify({ origin: 'home' }));
+    const consoleLogSpy = jest.spyOn(console, 'log');
+
+    sendScreenEvent('credit_list_view', { campaign_name: 'black_friday' });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '[blu-lytics]: Screen event: credit_list_view - {"origin":"home","campaign_name":"black_friday"}',
+    );
+  });
+
+  describe('production dispatch (non-development)', () => {
+    beforeEach(() => {
+      localStorage.setItem('_bl_env', 'production');
+      // Remove the providers allow-list so the dispatcher falls back to the
+      // full (mocked) providersList instead of filtering by name.
+      localStorage.removeItem('_bl_providers');
+    });
+
+    afterEach(() => {
+      localStorage.removeItem('_bl_env');
+    });
+
+    it('should call provider.screenEvent with only the screen when no properties are provided', () => {
+      sendScreenEvent('TestScreen');
+
+      expect(providersList[0].screenEvent).toHaveBeenCalledWith(
+        'TestScreen',
+        undefined,
+      );
+    });
+
+    it('should call provider.screenEvent with the screen and merged properties', () => {
+      localStorage.setItem('_bl_props', JSON.stringify({ origin: 'home' }));
+
+      sendScreenEvent('credit_list_view', {
+        campaign_name: 'black_friday',
+        opportunities_pagblu_count: 3,
+      });
+
+      expect(providersList[0].screenEvent).toHaveBeenCalledWith(
+        'credit_list_view',
+        {
+          origin: 'home',
+          campaign_name: 'black_friday',
+          opportunities_pagblu_count: 3,
+        },
+      );
+    });
   });
 
   it('should be dispatch sendCustomEvent', () => {

--- a/src/dispatchers/dispatchers.spec.ts
+++ b/src/dispatchers/dispatchers.spec.ts
@@ -46,7 +46,7 @@ describe('Event dispatching functions', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith('[blu-lytics]: Screen event: TestScreen');
   });
 
-  it('should dispatch sendScreenEvent without properties keeping the legacy log format', () => {
+  it('should dispatch sendScreenEvent without properties keeping the legacy log format when _bl_props is empty', () => {
     const consoleLogSpy = jest.spyOn(console, 'log');
 
     sendScreenEvent('TestScreen');
@@ -54,6 +54,17 @@ describe('Event dispatching functions', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith('[blu-lytics]: Screen event: TestScreen');
     expect(consoleLogSpy).not.toHaveBeenCalledWith(
       expect.stringContaining('TestScreen - '),
+    );
+  });
+
+  it('should include defaultProperties in log when _bl_props has content and no explicit properties are passed', () => {
+    localStorage.setItem('_bl_props', JSON.stringify({ client_uuid: 'abc123' }));
+    const consoleLogSpy = jest.spyOn(console, 'log');
+
+    sendScreenEvent('home_view');
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '[blu-lytics]: Screen event: home_view - {"client_uuid":"abc123"}',
     );
   });
 
@@ -80,12 +91,23 @@ describe('Event dispatching functions', () => {
       localStorage.removeItem('_bl_env');
     });
 
-    it('should call provider.screenEvent with only the screen when no properties are provided', () => {
+    it('should call provider.screenEvent with only the screen when no properties are provided and _bl_props is empty', () => {
       sendScreenEvent('TestScreen');
 
       expect(providersList[0].screenEvent).toHaveBeenCalledWith(
         'TestScreen',
         undefined,
+      );
+    });
+
+    it('should call provider.screenEvent with defaultProperties when _bl_props has content and no explicit properties are passed', () => {
+      localStorage.setItem('_bl_props', JSON.stringify({ client_uuid: 'abc123', is_economic_group: false }));
+
+      sendScreenEvent('home_view');
+
+      expect(providersList[0].screenEvent).toHaveBeenCalledWith(
+        'home_view',
+        { client_uuid: 'abc123', is_economic_group: false },
       );
     });
 

--- a/src/dispatchers/index.ts
+++ b/src/dispatchers/index.ts
@@ -31,7 +31,7 @@ export const dispatchEventToAllProviders = (eventData: EventData): void => {
         screenEvent: () =>
           provider.screenEvent &&
           eventData.screen &&
-          provider.screenEvent(eventData.screen),
+          provider.screenEvent(eventData.screen, eventData.properties),
         customEvent: () =>
           provider.customEvent &&
           eventData.event &&
@@ -54,14 +54,6 @@ const getIsDevelopment = (): boolean => {
   return currentEnvironment === 'development';
 };
 
-const sendScreenEvent = (screen: string): void => {
-  if (getIsDevelopment()) {
-    console.log(`[blu-lytics]: Screen event: ${screen}`);
-  } else {
-    dispatchEventToAllProviders({ screen });
-  }
-};
-
 const saveDefaultPropertiesToLocalStorage = (
   properties: PropertiesType,
 ): void => {
@@ -78,6 +70,45 @@ let defaultProperties: PropertiesType = loadDefaultPropertiesFromLocalStorage();
 const setDefaultProperties = (properties: PropertiesType): void => {
   defaultProperties = { ...properties };
   saveDefaultPropertiesToLocalStorage(defaultProperties);
+};
+
+const sendScreenEvent = (
+  screen: string,
+  properties?: PropertiesType,
+): void => {
+  if (!properties) {
+    if (getIsDevelopment()) {
+      console.log(`[blu-lytics]: Screen event: ${screen}`);
+    } else {
+      dispatchEventToAllProviders({ screen });
+    }
+    return;
+  }
+
+  const rawStoredProperties = localStorage.getItem('_bl_props');
+
+  if (rawStoredProperties) {
+    try {
+      defaultProperties = JSON.parse(rawStoredProperties);
+    } catch (error) {
+      console.error('[blu-lytics] Failed to parse stored properties', error);
+    }
+  }
+
+  const mergedProperties = {
+    ...defaultProperties,
+    ...properties,
+  };
+
+  if (getIsDevelopment()) {
+    console.log(
+      `[blu-lytics]: Screen event: ${screen} - ${JSON.stringify(
+        mergedProperties,
+      )}`,
+    );
+  } else {
+    dispatchEventToAllProviders({ screen, properties: mergedProperties });
+  }
 };
 
 const sendCustomEvent = (event: string, properties: PropertiesType): void => {

--- a/src/dispatchers/index.ts
+++ b/src/dispatchers/index.ts
@@ -76,15 +76,6 @@ const sendScreenEvent = (
   screen: string,
   properties?: PropertiesType,
 ): void => {
-  if (!properties) {
-    if (getIsDevelopment()) {
-      console.log(`[blu-lytics]: Screen event: ${screen}`);
-    } else {
-      dispatchEventToAllProviders({ screen });
-    }
-    return;
-  }
-
   const rawStoredProperties = localStorage.getItem('_bl_props');
 
   if (rawStoredProperties) {
@@ -95,19 +86,20 @@ const sendScreenEvent = (
     }
   }
 
-  const mergedProperties = {
-    ...defaultProperties,
-    ...properties,
-  };
+  const mergedProperties = { ...defaultProperties, ...properties };
+  const hasProperties = Object.keys(mergedProperties).length > 0;
 
   if (getIsDevelopment()) {
     console.log(
-      `[blu-lytics]: Screen event: ${screen} - ${JSON.stringify(
-        mergedProperties,
-      )}`,
+      hasProperties
+        ? `[blu-lytics]: Screen event: ${screen} - ${JSON.stringify(mergedProperties)}`
+        : `[blu-lytics]: Screen event: ${screen}`,
     );
   } else {
-    dispatchEventToAllProviders({ screen, properties: mergedProperties });
+    dispatchEventToAllProviders({
+      screen,
+      ...(hasProperties ? { properties: mergedProperties } : {}),
+    });
   }
 };
 

--- a/src/providers/provider.types.ts
+++ b/src/providers/provider.types.ts
@@ -4,6 +4,6 @@ export type ProviderType = {
   name: 'Clarity' | 'Sentry' | 'FullStory' | 'MixPanel';
   userIdentification: (id: string, userProperties: any) => void;
   customEvent: (event: string, properties: PropertiesType) => void;
-  screenEvent: (screen: string) => void;
+  screenEvent: (screen: string, properties?: PropertiesType) => void;
   reset?: () => void;
 };

--- a/src/providers/setups/clarity/clarity.ts
+++ b/src/providers/setups/clarity/clarity.ts
@@ -22,7 +22,10 @@ const dispatchCustomEvent = (
 ): void => {
 };
 
-const dispatchScreenEvent = (screen: string): void => {
+const dispatchScreenEvent = (
+  screen: string,
+  properties?: PropertiesType,
+): void => {
 };
 
 const ClarityProvider: ProviderType = {

--- a/src/providers/setups/fullstory/fullstory.spec.ts
+++ b/src/providers/setups/fullstory/fullstory.spec.ts
@@ -38,4 +38,13 @@ describe('FullStoryProvider', () => {
 
     expect(FullStory.event).toHaveBeenCalledWith(screen, {});
   });
+
+  it('dispatchScreenEvent should call FullStory.event with properties when provided', () => {
+    const screen = 'credit_list_view';
+    const properties = { origin: 'home', campaign_name: 'black_friday' };
+
+    FullStoryProvider.screenEvent(screen, properties);
+
+    expect(FullStory.event).toHaveBeenCalledWith(screen, { properties });
+  });
 });

--- a/src/providers/setups/fullstory/fullstory.ts
+++ b/src/providers/setups/fullstory/fullstory.ts
@@ -23,8 +23,11 @@ const dispatchCustomEvent = (
   FullStory.event(event, { properties });
 };
 
-const dispatchScreenEvent = (screen: string): void => {
-  FullStory.event(screen, {});
+const dispatchScreenEvent = (
+  screen: string,
+  properties?: PropertiesType,
+): void => {
+  FullStory.event(screen, properties ? { properties } : {});
 };
 
 const FullStoryProvider: ProviderType = {

--- a/src/providers/setups/mixpanel/mixpanel.spec.ts
+++ b/src/providers/setups/mixpanel/mixpanel.spec.ts
@@ -56,4 +56,18 @@ describe('MixPanelProvider', () => {
     jest.runAllTimers();
     expect(mixpanel.track).toHaveBeenCalledWith(screen);
   });
+
+  test('dispatchScreenEvent should call mixpanel.track with screen and properties', () => {
+    const screen = 'credit_list_view';
+    const properties = {
+      origin: 'home',
+      campaign_name: 'black_friday',
+      opportunities_pagblu_count: 3,
+    };
+
+    MixPanelProvider.screenEvent(screen, properties);
+
+    jest.runAllTimers();
+    expect(mixpanel.track).toHaveBeenCalledWith(screen, { ...properties });
+  });
 });

--- a/src/providers/setups/mixpanel/mixpanel.ts
+++ b/src/providers/setups/mixpanel/mixpanel.ts
@@ -48,10 +48,17 @@ const dispatchCustomEvent = (
   }
 };
 
-const dispatchScreenEvent = (screen: string): void => {
+const dispatchScreenEvent = (
+  screen: string,
+  properties?: PropertiesType,
+): void => {
   try {
     setTimeout(() => {
-      mixpanel.track(screen);
+      if (properties) {
+        mixpanel.track(screen, { ...properties });
+      } else {
+        mixpanel.track(screen);
+      }
     }, 1000);
   } catch (error) {
     console.error('Error tracking screen event:', error);

--- a/src/providers/setups/sentry/sentry.spec.ts
+++ b/src/providers/setups/sentry/sentry.spec.ts
@@ -64,4 +64,19 @@ describe('SentryProvider', () => {
       type: 'info',
     });
   });
+
+  it('dispatchScreenEvent should add breadcrumb with data when properties are provided', () => {
+    const screenName = 'credit_list_view';
+    const properties = { origin: 'home', campaign_name: 'black_friday' };
+
+    SentryProvider.screenEvent(screenName, properties);
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'screen',
+      message: screenName,
+      level: 'info',
+      type: 'info',
+      data: properties,
+    });
+  });
 });

--- a/src/providers/setups/sentry/sentry.ts
+++ b/src/providers/setups/sentry/sentry.ts
@@ -35,12 +35,16 @@ const dispatchCustomEvent = (
   Sentry.addBreadcrumb(breadcrumb);
 };
 
-const dispatchScreenEvent = (screen: string): void => {
+const dispatchScreenEvent = (
+  screen: string,
+  properties?: PropertiesType,
+): void => {
   const breadcrumb = {
     category: 'screen',
     message: screen,
     level: Sentry.Severity.Info,
     type: 'info',
+    ...(properties ? { data: properties } : {}),
   };
   Sentry.addBreadcrumb(breadcrumb);
 };


### PR DESCRIPTION
# Description

Faz \`sendScreenEvent\` aceitar **propriedades opcionais** e propagá-las aos providers, mesclando com as \`defaultProperties\` — exatamente como o \`sendCustomEvent\` já faz. Isso destrava os novos screen events de crédito (\`credit_list_view\`, \`credit_details_view\`) que precisam carregar propriedades como \`origin\`, \`referral\`, \`campaign_name\`, \`opportunities_pagblu_count\` e \`opportunities_billets_count\`.

Equivalente **web** dos PRs Android #3670 / iOS #2199, que alinharam os screen events ao \`logEvent\`.

## O que mudou

- \`sendScreenEvent(screen, properties?)\`: sempre lê \`_bl_props\` do localStorage e faz \`merged = { ...defaultProperties, ...properties }\`. Se \`merged\` for vazio, mantém \`{ screen }\` sem o campo \`properties\` (protege contra envio de objeto vazio aos SDKs). Se \`merged\` tiver conteúdo, despacha \`{ screen, properties: merged }\`.
- \`dispatchEventToAllProviders\`: a action \`screenEvent\` passa a chamar \`provider.screenEvent(eventData.screen, eventData.properties)\`.
- \`ProviderType.screenEvent\`: assinatura passa a \`(screen: string, properties?: PropertiesType) => void\`.
- Setups de provider atualizados para aceitar e repassar \`properties\`:
  - **Mixpanel** — \`mixpanel.track(screen, { ...properties })\` quando há props; sem props mantém \`mixpanel.track(screen)\`.
  - **FullStory** — \`FullStory.event(screen, { properties })\` quando há props; sem props mantém \`{}\`.
  - **Sentry** — adiciona \`data: properties\` ao breadcrumb quando há props; sem props o breadcrumb fica idêntico ao atual.
  - **Clarity** — \`screenEvent\` é no-op; assinatura atualizada para receber e ignorar.

## Impacto em eventos existentes

Esta mudança **não é retrocompatível no sentido estrito** — e isso é intencional.

Em produção, \`_bl_props\` já está populado após o login (via \`setDefaultProperties\` com \`client_uuid\`, \`is_economic_group\`, etc.). Com esse PR, **todos os screen events existentes** passarão a carregar esses parâmetros globais, que antes chegavam \`undefined\` nos providers.

Isso **alinha o web com Android e iOS**, onde parâmetros globais sempre acompanham todos os eventos. Não há risco de quebra funcional (os eventos continuam disparando), mas dashboards de analytics que dependiam da ausência dessas propriedades em screen events precisam ser revisados.

O único cenário onde o comportamento é 100% idêntico ao atual é quando \`_bl_props\` está vazio — o que não acontece em sessões autenticadas.

## Type of change

- [x] New feature _(non-breaking change which adds functionality)_

# Checklist

- [x] Perform a code self-review
- [x] Cover changes with tests
- [x] Make sure types are fine — \`tsc --declaration\` sem erros

# Testes

- \`sendScreenEvent\` sem props e \`_bl_props\` vazio → provider recebe \`(screen, undefined)\`
- \`sendScreenEvent\` sem props e \`_bl_props\` com globals → provider recebe globals
- \`sendScreenEvent\` com props e globals → provider recebe merged
- \`sendScreenEvent\` com props sem globals → provider recebe só as props explícitas

# Contexto / Links

- Jira: **MR-495**
- Referências: Android #3670, iOS #2199

🤖 Generated with [Claude Code](https://claude.com/claude-code)