### PR TITLE
fix: remove @semantic-release/git to unblock CD pipeline

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,13 +10,6 @@
         "npmPublish": true
       }
     ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary

- Remove `@semantic-release/git` plugin from `.releaserc.json`
- The plugin tentava fazer push direto na `main` (para commitar `package.json` + `CHANGELOG.md`), o que estava sendo bloqueado pela branch protection rule que exige PR
- O npm publish (`@semantic-release/npm`) e a criação do GitHub Release (`@semantic-release/github`) continuam funcionando normalmente

## Root Cause

```
remote: - Changes must be made through a pull request.
```

O `@semantic-release/git` roda na fase `prepare`, após o `@semantic-release/npm`, e tenta fazer `git push HEAD:main` direto — incompatível com a branch protection rule do repo.

## Test plan

- [ ] Merge este PR
- [ ] Verificar que o CD workflow (`cd.yml`) executa com sucesso no próximo push para `main`
- [ ] Confirmar que a nova versão foi publicada no npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)